### PR TITLE
Add sync_file_range syscall (reanimator-babeltrace)

### DIFF
--- a/plugins/text/pretty/fsl-pretty.c
+++ b/plugins/text/pretty/fsl-pretty.c
@@ -173,6 +173,7 @@ static void init_system_call_handlers()
 	ADD_SYSCALL_HANDLER("epoll_create1", &epoll_create1_syscall_handler);
 	ADD_SYSCALL_HANDLER("mmappread", &mmappread_syscall_handler);
 	ADD_SYSCALL_HANDLER("mmappwrite", &mmappwrite_syscall_handler);
+	ADD_SYSCALL_HANDLER("sync_file_range", &sync_file_range_syscall_handler);
 	buffer_file = fopen(bt_common_get_buffer_file_path(), "rb");
 }
 

--- a/plugins/text/pretty/fsl-syscall-handlers.c
+++ b/plugins/text/pretty/fsl-syscall-handlers.c
@@ -1258,6 +1258,18 @@ void epoll_create1_syscall_handler(long *args, void **v_args)
 	args[0] = get_value_for_args(flags);
 }
 
+void sync_file_range_syscall_handler(long *args, void **v_args)
+{
+	READ_SYSCALL_ARG(fd, "fd")
+	READ_SYSCALL_ARG(offset, "offset")
+	READ_SYSCALL_ARG(nbytes, "nbytes")
+	READ_SYSCALL_ARG(flags, "flags")
+	args[0] = get_value_for_args(fd)
+	args[1] = get_value_for_args(offset)
+	args[2] = get_value_for_args(nbytes)
+	args[3] = get_value_for_args(flags)
+}
+
 static uint64_t set_buffer(uint64_t entry_event_count, long *args,
 			   void **v_args, uint64_t args_idx,
 			   uint64_t v_args_idx, char *arg_name)

--- a/plugins/text/pretty/fsl-syscall-handlers.c
+++ b/plugins/text/pretty/fsl-syscall-handlers.c
@@ -1264,10 +1264,10 @@ void sync_file_range_syscall_handler(long *args, void **v_args)
 	READ_SYSCALL_ARG(offset, "offset")
 	READ_SYSCALL_ARG(nbytes, "nbytes")
 	READ_SYSCALL_ARG(flags, "flags")
-	args[0] = get_value_for_args(fd)
-	args[1] = get_value_for_args(offset)
-	args[2] = get_value_for_args(nbytes)
-	args[3] = get_value_for_args(flags)
+	args[0] = get_value_for_args(fd);
+	args[1] = get_value_for_args(offset);
+	args[2] = get_value_for_args(nbytes);
+	args[3] = get_value_for_args(flags);
 }
 
 static uint64_t set_buffer(uint64_t entry_event_count, long *args,

--- a/plugins/text/pretty/fsl-syscall-handlers.h
+++ b/plugins/text/pretty/fsl-syscall-handlers.h
@@ -108,5 +108,6 @@ void epoll_create_syscall_handler(long *args, void **v_args);
 void epoll_create1_syscall_handler(long *args, void **v_args);
 void mmappread_syscall_handler(long *args, void **v_args);
 void mmappwrite_syscall_handler(long *args, void **v_args);
+void sync_file_range_syscall_handler(long *args, void **v_args);
 
 #endif


### PR DESCRIPTION
Implements a previously unimplemented syscall found when attempting to trace db_bench with RocksDB.

`int sync_file_range(int fd, off64_t offset, off64_t nbytes, unsigned int flags);`